### PR TITLE
fix: scopeの設定をプロジェクト名に変更

### DIFF
--- a/re-bond/public/manifest.json
+++ b/re-bond/public/manifest.json
@@ -3,7 +3,7 @@
     "background_color": "#001683",
     "display": "standalone",
     "orientation": "any",
-    "scope": "/",
+    "scope": "/re-bond/",
     "start_url": "/",
     "name": "Re:Bond",
     "short_name": "Re:Bond",


### PR DESCRIPTION
manifest.jsonのスコープの名前を
```
"scope": "/re-bond/"
```
に変更
ローカルホストでは正常な動作をしているがdevで正常にインストール可能かマージ後に確認が必要